### PR TITLE
Remove unnecessary app.import of moment

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
-    this.app.import(app.bowerDirectory + '/moment/moment.js');
     this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.js');
     this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.css');
   }


### PR DESCRIPTION
Moment is imported manually into the vendor file which stomps all over the version installed by ember-moment via ember-cli-moment-shim. The shim version is preferable as it includes timezones.
